### PR TITLE
[Fix]fixed date on interest meeting card

### DIFF
--- a/src/content/events/interest_meeting_s26.mdx
+++ b/src/content/events/interest_meeting_s26.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ACM Spring 2027 Interest Meeting"
+title: "Spring 2026 Interest Meeting"
 date: 2026-1-22T18:00:00-05:00
 endDate: 2026-1-22T19:00:00-05:00
 image: ../../assets/events/interest_meeting_s26/lobby.jpg


### PR DESCRIPTION
Fixed typo in interest meeting event where the year was 2027 instead of 2026